### PR TITLE
⚡ Automatic Build & Releases, Build Flavours, C++17, Apk Signing, Java 15, Gradle 6.9

### DIFF
--- a/.github/workflows/build-sdl2-android.yml
+++ b/.github/workflows/build-sdl2-android.yml
@@ -1,26 +1,53 @@
-name: build-sdl2-android
+name: build-and-release
 
 on:
   push:
     tags:
-    - v*
+      - v*
 
 jobs:
-  build-curator:
-    name: Build Android example
+  build-creator:
+    name: Build & Release APK
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+        uses: actions/checkout@v2.3.4
+      
+      - name: Get current time
+        uses: srfrnk/current-time@master
+        id: current-time
         with:
-          java-version: 11
-      - name: Build all artifacts
-        id: buildAllApks
-        uses: eskatos/gradle-command-action@v1
+          format: DD-MM-YYYY
+      
+      - name: Updating Build Tools
+        run: sudo apt update && sudo apt upgrade
+      
+      - name: Setup Java Envirionment
+        uses: actions/setup-java@v2.1.0
         with:
-          gradle-version: current
+          distribution: adopt-hotspot
+          java-version: 15
+      
+      - name: Building with Gradle
+        uses: eskatos/gradle-command-action@v1.3.3
+        with:
+          gradle-version: 6.9
           wrapper-cache-enabled: true
           dependencies-cache-enabled: true
           configuration-cache-enabled: true
-          arguments: assembleRelease
+          arguments: 'build -x lint'
+      
+      - name: Upload APK Files to Release
+        uses: softprops/action-gh-release@v1
+        with:
+          name: "Auto Build ${{ steps.current-time.outputs.formattedTime }}"
+#          tag_name: v1.0.2
+          prerelease: true
+          body: |
+            This is an Automatic Release by GitHub Actions.
+            APK marked "unsigned" needs to be signed with test key before installing.
+            This may change in Future.
+          files: |
+            ./app/build/outputs/apk/*/*/*.apk
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Source code:
 
 ### Gradle
 
-The project is based on Gradle 5. For older version based on Gradle 4 and Android Experimental Plugin, check out branch gradle-4-using-android-experimental-plugin.
+The project is compatible with Gradle 5 & 6. For older version based on Gradle 4 and Android Experimental Plugin, check out branch gradle-4-using-android-experimental-plugin.
 
-Android build Tools are set to 27.0.3 in file settings.gradle. Make sure to download those tools via Android Studio.
+Android build Tools are set to v28.0.0 in file settings.gradle. Make sure to download those tools via Android Studio.
 
 
 ### Libraries

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,11 +43,53 @@ apply plugin: 'kotlin-android-extensions'
                 }   
             }
         }   */
+        productFlavors {
+            flavorDimensions 'abi'
+            
+            arm {
+                ndk {
+                    abiFilter 'armeabi-v7a'
+                }
+            }
+            arm64 {
+                ndk {
+                    abiFilter 'arm64-v8a'
+                }
+            }
+            x86 {
+                ndk {
+                    abiFilter 'x86'
+                }
+            }
+            x86_64 {
+                ndk {
+                    abiFilter 'x86_64'
+                }
+            }
+            all_in_one {
+                ndk {
+                    //abiFilter 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+                }
+            }
+        }
+        signingConfigs {
+            release {
+                storeFile file("keystore-path")
+                storePassword "keystore-pass"
+                keyAlias "alias"
+                keyPassword "alias-password"
 
+                // Optional, specify signing versions used
+                v1SigningEnabled true
+                v2SigningEnabled true
+            }
+        }
         buildTypes {
             release {
                 minifyEnabled = false
                 proguardFiles.add(file('proguard-rules.txt'))
+                // Uncomment to enable apk signing (and also fill details in signingConfigs Block)
+                //signingConfig signingConfigs.release
             }
         }
         externalNativeBuild {

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 3.4.1)
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 include_directories(
         ${CMAKE_CURRENT_SOURCE_DIR}/../SDL2/include


### PR DESCRIPTION
Just publish a new tag to trigger build system.

Apk download assets should be available within 10 minutes from creating a new tag. (It takes 10 min to compile on average)

**Release Example :-**
![IMG_20210524_113818](https://user-images.githubusercontent.com/68330937/119304228-95364980-bc84-11eb-954a-d81f10ce5088.jpg)

**Change logs :-**
1. Automatic Builds and Releases
2. Automatic Apk signing (put a keystore in "app" folder, then fill in passwords and uncomment the signing config line in "app/build.gradle")
3. Apk is now built in 5 different flavours. (arm, arm64, x86, x86_64, all_in_one)
4. Set Gradle to version 6.9
5. Set Java JDK to version 15
6. Updated Readme